### PR TITLE
Add remote prewarm documentation and examples into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ SELECT prewarm_remote('/tmp/cache_httpfs/data_*.csv');
 | `pattern` | **(Required)** URL or file path pattern to prewarm. Supports glob patterns. |
 | `max_bytes` | **(Optional)** Maximum number of bytes to prewarm. Defaults to unlimited. |
 
-> **Note:** `prewarm_remote` requires the `cache_httpfs` extension to be loaded. The block size is determined by the `cache_httpfs_cache_block_size` setting.
+> **Note:** `prewarm_remote` loads `cache_httpfs` extension internally. The block size is determined by the `cache_httpfs_cache_block_size` setting.
 > **Note:** The returned byte count includes all blocks processed, even if they were already cached in memory or on local disk. Blocks that are already warm are still counted toward the prewarmed bytes total.
 
 ## When to Use


### PR DESCRIPTION
Closes: https://github.com/dentiny/duckdb-cache-prewarm/issues/48

This pull request updates the documentation in `README.md` to add comprehensive examples and explanations for the new remote prewarm functionality using `cache_httpfs`, clarify the behavior of prewarm functions, and improve the accuracy of result descriptions. The changes also mark remote file/table support as implemented.

### Remote prewarm functionality and documentation

* Added detailed usage examples for the new `prewarm_remote` function, including human-readable and raw byte size limits, glob pattern support, and configuration notes for `cache_httpfs`.
* Provided step-by-step examples for configuring `cache_httpfs` and prewarming remote files, with clear explanations of return values and caveats regarding compression and data layout.
* Updated the feature checklist to mark remote table and file support as implemented, referencing the relevant issue.

### Behavior clarification and improved examples

* Clarified that the return value of `prewarm` and `prewarm_remote` is the number of bytes prewarmed, replacing previous references to blocks, and updated example values accordingly.
* Improved SQL examples and notes to distinguish between local and remote prewarm scenarios and to clarify parameter usage, including qualified table names and size limits.